### PR TITLE
Moved Cleaner implementation to infrastructure making it generic

### DIFF
--- a/ChustaSoft.GamersPlatformUtils.Abstractions/Contracts/IPlatformFactory.cs
+++ b/ChustaSoft.GamersPlatformUtils.Abstractions/Contracts/IPlatformFactory.cs
@@ -8,8 +8,6 @@ namespace ChustaSoft.GamersPlatformUtils.Abstractions
 
         IDictionary<string, IAnalyzer> GetAnalyzers();
 
-        IDictionary<string, ICleaner> GetCleaners();
-
         IDictionary<string, ILinkFinder> GetLinkFinders();
 
         IDictionary<string, ILinkAssigner> GetLinkAssigners();

--- a/ChustaSoft.GamersPlatformUtils.Abstractions/Repositories/IFileDeleteRepository.cs
+++ b/ChustaSoft.GamersPlatformUtils.Abstractions/Repositories/IFileDeleteRepository.cs
@@ -4,8 +4,8 @@ using System.Threading.Tasks;
 
 namespace ChustaSoft.GamersPlatformUtils.Abstractions
 {
-    public interface ICleaner
+    public interface IFileDeleteRepository
     {
-        Task<CleanResult> CleanAsync(IEnumerable<FileInfo> paths);
+        Task<CleanResult> DeleteAsync(IEnumerable<FileInfo> paths);
     }
 }

--- a/ChustaSoft.GamersPlatformUtils.Domain.Steam/Contracts/ISteamBusiness.cs
+++ b/ChustaSoft.GamersPlatformUtils.Domain.Steam/Contracts/ISteamBusiness.cs
@@ -2,5 +2,5 @@
 
 namespace ChustaSoft.GamersPlatformUtils.Domain
 {
-    public interface ISteamBusiness : IPlatform, IAnalyzer, ICleaner { }
+    public interface ISteamBusiness : IPlatform, IAnalyzer { }
 }

--- a/ChustaSoft.GamersPlatformUtils.Domain.Steam/Implementations/SteamBusiness.cs
+++ b/ChustaSoft.GamersPlatformUtils.Domain.Steam/Implementations/SteamBusiness.cs
@@ -1,6 +1,5 @@
 ﻿using ChustaSoft.GamersPlatformUtils.Abstractions;
 using Microsoft.Win32;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace ChustaSoft.GamersPlatformUtils.Domain
 {
-    public class SteamBusiness : PlatformBase, ISteamBusiness, IAnalyzer, ICleaner
+    public class SteamBusiness : PlatformBase, ISteamBusiness, IAnalyzer
     {
 
         public SteamBusiness()
@@ -32,34 +31,6 @@ namespace ChustaSoft.GamersPlatformUtils.Domain
             return await Task.Run(() => GetFiles(commonSteamPath));
         }
 
-        public async Task<CleanResult> CleanAsync(IEnumerable<FileInfo> paths)
-        {
-            return await Task.Run(() =>
-            {
-                var result = new CleanResult();
-
-                foreach (FileInfo file in paths)
-                {
-                    try
-                    {
-                        if (!file.IsReadOnly)
-                        {
-                            file.Delete();
-                            result.CleanedDirectories++;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        result.ErrorList.Add(file.FullName, ex.Message);
-                    }
-                }
-
-                if (result.ErrorList.Any())
-                    result.Success = false;
-
-                return result;
-            });
-        }
 
         protected override void LoadPlatform()
         {
@@ -103,5 +74,6 @@ namespace ChustaSoft.GamersPlatformUtils.Domain
 
             return files.OrderBy(x => x.FullName);
         }
+
     }
 }

--- a/ChustaSoft.GamersPlatformUtils.Domain/Implementations/PlatformFactory.cs
+++ b/ChustaSoft.GamersPlatformUtils.Domain/Implementations/PlatformFactory.cs
@@ -29,11 +29,6 @@ namespace ChustaSoft.GamersPlatformUtils.Domain
             };
         }
 
-        public IDictionary<string, ICleaner> GetCleaners()
-        {
-            throw new NotImplementedException();
-        }
-
         public IDictionary<string, ILinkAssigner> GetLinkAssigners()
         {
             throw new NotImplementedException();

--- a/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests.csproj
+++ b/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chustasoft.GamersPlatformUtils.Infrastructure\Chustasoft.GamersPlatformUtils.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/SystemFileRepositoryTests.cs
+++ b/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/SystemFileRepositoryTests.cs
@@ -2,25 +2,56 @@ using Chustasoft.GamersPlatformUtils.Infrastructure.Implementations;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace ChustaSoft.GamersPlatformUtils.Infrastructure.Tests
 {
     public class SystemFileRepositoryTests
     {
+
+        private const string TEST_FILE_NAME = @"test.txt";
+
+
+        [SetUp]
+        public void InitializeTest() 
+        {
+            CheckFileExistingForDelete();
+
+            using (FileStream fs = File.Create(TEST_FILE_NAME))
+            {
+                byte[] title = new UTF8Encoding(true).GetBytes("Test text file");
+                fs.Write(title, 0, title.Length);
+                byte[] author = new UTF8Encoding(true).GetBytes("ChustaSoft");
+                fs.Write(author, 0, author.Length);
+            }
+        }
+
+        [TearDown]
+        public void FinalizeTest()
+        {
+            CheckFileExistingForDelete();
+        }
+
+
         [Test]
         public async Task Given_ListOfFileInfo_When_Clean_Then_ReturnSuccessCleanResult()
         {
-#if DEBUG 
             var systemFileRepository = new SystemFileRepository();
-            var files = new List<FileInfo> { new FileInfo("TestFile") };
+            var files = new List<FileInfo> { new FileInfo(TEST_FILE_NAME) };
 
             var cleanResult = await systemFileRepository.DeleteAsync(files);
 
             Assert.IsTrue(cleanResult.Success);
-#else
-            Assert.IsTrue(true);
-#endif
+            Assert.AreEqual(files.Count, cleanResult.CleanedDirectories);
         }
+
+
+        private static void CheckFileExistingForDelete()
+        {
+            if (File.Exists(TEST_FILE_NAME))
+                File.Delete(TEST_FILE_NAME);
+        }
+
     }
 }

--- a/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/SystemFileRepositoryTests.cs
+++ b/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/SystemFileRepositoryTests.cs
@@ -1,0 +1,26 @@
+using Chustasoft.GamersPlatformUtils.Infrastructure.Implementations;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ChustaSoft.GamersPlatformUtils.Infrastructure.Tests
+{
+    public class SystemFileRepositoryTests
+    {
+        [Test]
+        public async Task Given_ListOfFileInfo_When_Clean_Then_ReturnSuccessCleanResult()
+        {
+#if DEBUG 
+            var systemFileRepository = new SystemFileRepository();
+            var files = new List<FileInfo> { new FileInfo("TestFile") };
+
+            var cleanResult = await systemFileRepository.DeleteAsync(files);
+
+            Assert.IsTrue(cleanResult.Success);
+#else
+            Assert.IsTrue(true);
+#endif
+        }
+    }
+}

--- a/ChustaSoft.GamersPlatformUtils.Steam.Tests/SteamBusinessTests.cs
+++ b/ChustaSoft.GamersPlatformUtils.Steam.Tests/SteamBusinessTests.cs
@@ -35,19 +35,5 @@ namespace ChustaSoft.GamersPlatformUtils.Steam.Tests
 
         }
 
-        [Test]
-        public async Task Given_ListOfFileInfo_When_Clean_Then_ReturnSuccessCleanResult()
-        {
-#if DEBUG 
-            var steamPlatform = new SteamBusiness();
-            var files = await steamPlatform.AnalyzeAsync();
-
-            var cleanResult = await steamPlatform.CleanAsync(files.Take(1));
-
-            Assert.IsTrue(cleanResult.Success);
-#else
-            Assert.IsTrue(true);
-#endif
-        }
     }
 }

--- a/Chustasoft.GamersPlatformUtils.Infrastructure/Implementations/SystemFileRepository.cs
+++ b/Chustasoft.GamersPlatformUtils.Infrastructure/Implementations/SystemFileRepository.cs
@@ -1,0 +1,47 @@
+﻿using ChustaSoft.GamersPlatformUtils.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Chustasoft.GamersPlatformUtils.Infrastructure.Implementations
+{
+    public class SystemFileRepository : IFileDeleteRepository
+    {
+
+        public async Task<CleanResult> DeleteAsync(IEnumerable<FileInfo> paths)
+        {
+            return await Task.Run(() =>
+            {
+                var result = new CleanResult();
+
+                foreach (FileInfo file in paths)
+                    PerformRemove(result, file);
+
+                if (result.ErrorList.Any())
+                    result.Success = false;
+
+                return result;
+            });
+        }
+
+
+        private static void PerformRemove(CleanResult result, FileInfo file)
+        {
+            try
+            {
+                if (!file.IsReadOnly)
+                {
+                    file.Delete();
+                    result.CleanedDirectories++;
+                }
+            }
+            catch (Exception ex)
+            {
+                result.ErrorList.Add(file.FullName, ex.Message);
+            }
+        }
+
+    }
+}

--- a/GamersPlatformUtils.sln
+++ b/GamersPlatformUtils.sln
@@ -39,7 +39,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChustaSoft.GamersPlatformUt
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "4. Infrastructure", "4. Infrastructure", "{4497B662-259C-4270-8BC8-7414BFC428C1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chustasoft.GamersPlatformUtils.Infrastructure", "Chustasoft.GamersPlatformUtils.Infrastructure\Chustasoft.GamersPlatformUtils.Infrastructure.csproj", "{27C0742B-B80B-4F23-9D5F-24FE181BA2EC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chustasoft.GamersPlatformUtils.Infrastructure", "Chustasoft.GamersPlatformUtils.Infrastructure\Chustasoft.GamersPlatformUtils.Infrastructure.csproj", "{27C0742B-B80B-4F23-9D5F-24FE181BA2EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChustaSoft.GamersPlatformUtils.Infrastructure.Tests", "ChustaSoft.GamersPlatformUtils.Infrastructure.Tests\ChustaSoft.GamersPlatformUtils.Infrastructure.Tests.csproj", "{806B045B-7FB1-4B50-AD06-C0EB1E41EC87}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,6 +85,10 @@ Global
 		{27C0742B-B80B-4F23-9D5F-24FE181BA2EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27C0742B-B80B-4F23-9D5F-24FE181BA2EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27C0742B-B80B-4F23-9D5F-24FE181BA2EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{806B045B-7FB1-4B50-AD06-C0EB1E41EC87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{806B045B-7FB1-4B50-AD06-C0EB1E41EC87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{806B045B-7FB1-4B50-AD06-C0EB1E41EC87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{806B045B-7FB1-4B50-AD06-C0EB1E41EC87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,6 +103,7 @@ Global
 		{863E4D6A-0BDE-46B5-9B53-3CE146A255BB} = {E9D01F4A-74C0-4DEE-B42B-5679CCD1BE3D}
 		{8F98440B-8C54-4178-B978-8B5D8169B5C0} = {40FEA078-DA24-47EA-B6B9-4186BB6F8E53}
 		{27C0742B-B80B-4F23-9D5F-24FE181BA2EC} = {4497B662-259C-4270-8BC8-7414BFC428C1}
+		{806B045B-7FB1-4B50-AD06-C0EB1E41EC87} = {40FEA078-DA24-47EA-B6B9-4186BB6F8E53}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {28D3C08D-A3D9-46AA-ABF7-06FE63CF2907}


### PR DESCRIPTION
New Implementations

- #48 : Moved Cleaner implementation to infrastructure making it generic
  - Renamed contract for Cleaner
  - Moved implementation from Steam to Infrastructure
  - Created UnitTest project for infrastructure and moved the existing test method


[If no bug or not implementation has been added, remove the part from the PR description]