### PR TITLE
Cleaner and Linker tab alignment

### DIFF
--- a/ChustaSoft.GamersPlatformUtils.Domain.Steam/Implementations/SteamBusiness.cs
+++ b/ChustaSoft.GamersPlatformUtils.Domain.Steam/Implementations/SteamBusiness.cs
@@ -118,7 +118,7 @@ namespace ChustaSoft.GamersPlatformUtils.Domain
         {
             Regex pathRegex = new Regex(@"[A-Z]:\\\\(.*)", RegexOptions.IgnoreCase);
 
-            return pathRegex.Match(configLine).Value.Replace("\\\\", "\\");
+            return pathRegex.Match(configLine).Value.Replace("\\\\", "\\").Replace('"', ' ').Trim();
         }
 
     }

--- a/ChustaSoft.GamersPlatformUtils.Domain/ChustaSoft.GamersPlatformUtils.Domain.csproj
+++ b/ChustaSoft.GamersPlatformUtils.Domain/ChustaSoft.GamersPlatformUtils.Domain.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ChustaSoft.Common" Version="1.2.1" />
+    <PackageReference Include="ChustaSoft.Common" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests.csproj
+++ b/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests/ChustaSoft.GamersPlatformUtils.Infrastructure.Tests.csproj
@@ -8,8 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChustaSoft.GamersPlatformUtils.Services/ChustaSoft.GamersPlatformUtils.Services.csproj
+++ b/ChustaSoft.GamersPlatformUtils.Services/ChustaSoft.GamersPlatformUtils.Services.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ChustaSoft.GamersPlatformUtils.UI/ChustaSoft.GamersPlatformUtils.UI.csproj
+++ b/ChustaSoft.GamersPlatformUtils.UI/ChustaSoft.GamersPlatformUtils.UI.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ChustaSoft.Common.Wpf" Version="1.1.1" />
+    <PackageReference Include="ChustaSoft.Common.Wpf" Version="1.1.1.6" />
     <PackageReference Include="MaterialDesignThemes" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />

--- a/ChustaSoft.GamersPlatformUtils.UI/ChustaSoft.GamersPlatformUtils.UI.csproj
+++ b/ChustaSoft.GamersPlatformUtils.UI/ChustaSoft.GamersPlatformUtils.UI.csproj
@@ -29,10 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ChustaSoft.Common.Wpf" Version="1.1.1.6" />
-    <PackageReference Include="MaterialDesignThemes" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
+    <PackageReference Include="ChustaSoft.Common.Wpf" Version="1.2.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="NReco.Logging.File" Version="1.0.5" />
   </ItemGroup>

--- a/ChustaSoft.GamersPlatformUtils.UI/Controls/InformationControl.xaml
+++ b/ChustaSoft.GamersPlatformUtils.UI/Controls/InformationControl.xaml
@@ -3,12 +3,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:helpers="clr-namespace:ChustaSoft.Common.Helpers;assembly=ChustaSoft.Common.WPF"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
     <UserControl.Resources>
-        <helpers:VisibilityConverter x:Key="VisibilityConverter" />
+        <BooleanToVisibilityConverter x:Key="VisibilityConverter" />
     </UserControl.Resources>
 
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/ChustaSoft.GamersPlatformUtils.UI/Helpers/GameLinkMapper.cs
+++ b/ChustaSoft.GamersPlatformUtils.UI/Helpers/GameLinkMapper.cs
@@ -1,5 +1,8 @@
 ﻿using ChustaSoft.Common.Models;
 using ChustaSoft.GamersPlatformUtils.Abstractions;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ChustaSoft.GamersPlatformUtils.UI.Helpers
 {
@@ -14,6 +17,9 @@ namespace ChustaSoft.GamersPlatformUtils.UI.Helpers
                 Selected = false
             };
         }
+
+        public static ObservableCollection<SelectableOption<GameLink>> Map(this IEnumerable<GameLink> source)
+            => new ObservableCollection<SelectableOption<GameLink>>(source.Select(Map));
 
     }
 }

--- a/ChustaSoft.GamersPlatformUtils.UI/MainWindow.xaml
+++ b/ChustaSoft.GamersPlatformUtils.UI/MainWindow.xaml
@@ -54,13 +54,13 @@
                     </Setter>
                 </Style>
             </TabControl.Resources>
-            <TabItem Header="Cleaner" Width="200">
+            <TabItem Header="Cleaner" Width="200" Height="35">
                 <Grid Background="{DynamicResource MaterialDesignCardBackground}">
                     <cleaner:CleanerControl DataContext="{Binding CleanerControlViewModel}"></cleaner:CleanerControl>
                 </Grid>
             </TabItem>
-            
-            <TabItem Header="Linker" Width="200">
+
+            <TabItem Header="Linker" Width="200" Height="35">
                 <Grid Background="{DynamicResource MaterialDesignCardBackground}">
                     <linker:LinkerControl DataContext="{Binding LinkerControlViewModel}"></linker:LinkerControl>
                 </Grid>

--- a/ChustaSoft.GamersPlatformUtils.UI/Modules/Cleaner/CleanerControl.xaml
+++ b/ChustaSoft.GamersPlatformUtils.UI/Modules/Cleaner/CleanerControl.xaml
@@ -5,7 +5,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="clr-namespace:ChustaSoft.Common.Controls;assembly=ChustaSoft.Common.WPF"
-             xmlns:helpers="clr-namespace:ChustaSoft.Common.Helpers;assembly=ChustaSoft.Common.WPF"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
@@ -14,7 +13,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Card.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <helpers:VisibilityConverter x:Key="VisibilityConverter" /> 
+            <BooleanToVisibilityConverter x:Key="VisibilityConverter" /> 
         </ResourceDictionary>
     </UserControl.Resources>
 

--- a/ChustaSoft.GamersPlatformUtils.UI/Modules/Cleaner/CleanerControl.xaml
+++ b/ChustaSoft.GamersPlatformUtils.UI/Modules/Cleaner/CleanerControl.xaml
@@ -59,7 +59,9 @@
                 <Button Content="Clean" Command="{Binding CleanCommand}" Margin="{Binding ButtonMargins}"></Button>
             </StackPanel>
         </materialDesign:Card>
-        
+
+        <controls:Loading x:Name="loadingControl" Grid.Row="0" Text="Loading ..." HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" BackgroundColor="{DynamicResource MaterialDesignCardBackground}" TextColor="#ffffff" PanelOpacity="0.5" Visible="{Binding IsLoading, Mode=OneWay}" LoadingPosition="Top" />
+
     </Grid>
     
 </UserControl>

--- a/ChustaSoft.GamersPlatformUtils.UI/Modules/Cleaner/CleanerControlModel.cs
+++ b/ChustaSoft.GamersPlatformUtils.UI/Modules/Cleaner/CleanerControlModel.cs
@@ -32,6 +32,7 @@ namespace ChustaSoft.GamersPlatformUtils.UI.Modules.Cleaner
         }
         public bool HasResults => PathsAnalyzed.Any();
 
+
         public CleanerControlModel()
         {
             SetEmptyPlatforms();
@@ -49,8 +50,6 @@ namespace ChustaSoft.GamersPlatformUtils.UI.Modules.Cleaner
             foreach (var filePathSelect in PathsAnalyzed)
                 filePathSelect.Selected = multipleSelection;
         }
-
-        
 
 
         private void SetEmptyPlatforms()

--- a/ChustaSoft.GamersPlatformUtils.UI/Modules/Linker/LinkerControl.xaml
+++ b/ChustaSoft.GamersPlatformUtils.UI/Modules/Linker/LinkerControl.xaml
@@ -1,10 +1,10 @@
-﻿<UserControl x:Class="ChustaSoft.GamersPlatformUtils.UI.Modules.Linker.LinkerControl"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:ChustaSoft.Common.Controls;assembly=ChustaSoft.Common.WPF"             
+﻿<UserControl x:Class="ChustaSoft.GamersPlatformUtils.UI.Modules.Linker.LinkerControl" 
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:controls="clr-namespace:ChustaSoft.Common.Controls;assembly=ChustaSoft.Common.WPF" 
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
@@ -13,6 +13,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Card.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="VisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -22,7 +23,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <ListView Grid.Row="0" ItemsSource="{Binding Model.PathsAnalyzed}" ScrollViewer.CanContentScroll="True" >
+        <ListView Grid.Row="0" ItemsSource="{Binding Model.PathsAnalyzed}" ScrollViewer.CanContentScroll="True" Visibility="{Binding !IsLoading, Mode=OneWay, Converter={StaticResource VisibilityConverter}}" >
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <StackPanel Orientation="Horizontal">
@@ -42,7 +43,7 @@
             </StackPanel>
         </materialDesign:Card>
 
-        <controls:Loading x:Name="loadingControl" Text="Loading ..." BackgroundColor="#555577" TextColor="#ffffff" PanelOpacity="0.5" Visible="{Binding IsLoading, Mode=OneWay}" TopBarVisible="False" BottomBarVisible="True" Width="400" />
+        <controls:Loading x:Name="loadingControl" Grid.Row="0" Text="Loading ..." HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" BackgroundColor="{DynamicResource MaterialDesignCardBackground}" TextColor="#ffffff" PanelOpacity="0.5" Visible="{Binding IsLoading, Mode=OneWay}" LoadingPosition="Top" />
 
     </Grid>
 

--- a/ChustaSoft.GamersPlatformUtils.UI/Modules/Linker/LinkerControl.xaml
+++ b/ChustaSoft.GamersPlatformUtils.UI/Modules/Linker/LinkerControl.xaml
@@ -23,16 +23,35 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <ListView Grid.Row="0" ItemsSource="{Binding Model.PathsAnalyzed}" ScrollViewer.CanContentScroll="True" Visibility="{Binding !IsLoading, Mode=OneWay, Converter={StaticResource VisibilityConverter}}" >
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox IsChecked="{Binding Path=Selected, Mode=TwoWay}" Margin="0 0 10 0" />
-                        <TextBlock Text="{Binding Path=Value.Name, Mode=OneWay}" />
-                    </StackPanel>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <StackPanel Orientation="Vertical">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Visibility="{Binding Model.HasResults, Converter={StaticResource VisibilityConverter}, Mode=OneWay}">
+                <Button 
+                        Content="{materialDesign:PackIcon CheckAll}" ToolTip="Select / Unselect all"
+                        Style="{DynamicResource MaterialDesignFloatingActionLightButton}" Height="25" Width="25" Margin="0 5 5 0"
+                        Command="{Binding ChangeAllSelectionCommand}">
+                </Button>
+                <Button 
+                        Content="{materialDesign:PackIcon Clear}" ToolTip="Clear results"
+                        Style="{DynamicResource MaterialDesignFloatingActionDarkButton}" Height="25" Width="25" Margin="0 5 5 0"
+                        Command="{Binding ClearCommand}">
+                </Button>
+            </StackPanel>
+
+
+            <ListView Grid.Row="0" ItemsSource="{Binding Model.PathsAnalyzed}" ScrollViewer.CanContentScroll="True" Visibility="{Binding !IsLoading, Mode=OneWay, Converter={StaticResource VisibilityConverter}}" >
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <CheckBox IsChecked="{Binding Path=Selected, Mode=TwoWay}" Margin="0 0 10 0" />
+                            <TextBlock Text="{Binding Path=Value.Name, Mode=OneWay}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <materialDesign:Snackbar IsActive="{Binding CleanCompleted}" ActionButtonStyle="{StaticResource MaterialDesignSnackbarActionDarkButton}" >
+                <materialDesign:SnackbarMessage Content="{Binding CleanResultMessage}" ActionContent="Discard" ActionCommand="{Binding DiscardCommand}" />
+            </materialDesign:Snackbar>
+        </StackPanel>
 
         <materialDesign:Card Grid.Row="1" Height="50">
             <StackPanel  Orientation="Horizontal" HorizontalAlignment="Right">

--- a/ChustaSoft.GamersPlatformUtils.UI/Modules/Linker/LinkerControlModel.cs
+++ b/ChustaSoft.GamersPlatformUtils.UI/Modules/Linker/LinkerControlModel.cs
@@ -2,12 +2,12 @@
 using ChustaSoft.Common.Models;
 using ChustaSoft.GamersPlatformUtils.Abstractions;
 using System.Collections.ObjectModel;
-using System.IO;
+using System.Linq;
 
 namespace ChustaSoft.GamersPlatformUtils.UI.Modules.Linker
 {
     public class LinkerControlModel : ViewModelBase
-    {        
+    {
 
         private ObservableCollection<SelectableOption> _platformsSource;
         public ObservableCollection<SelectableOption> PlatformsSource
@@ -38,15 +38,40 @@ namespace ChustaSoft.GamersPlatformUtils.UI.Modules.Linker
             {
                 _pathsAnalyzed = value;
                 OnPropertyChanged(nameof(PathsAnalyzed));
+                OnPropertyChanged(nameof(HasResults));
             }
         }
 
+        public bool HasResults => PathsAnalyzed.Any();
 
-        public LinkerControlModel() 
+
+        public LinkerControlModel()
+        {
+            SetEmptyPlatforms();
+            SetEmptyPaths();
+        }
+
+
+        internal void ClearPaths()
+        {
+            SetEmptyPaths();
+        }
+
+        internal void ChangeAllPathsSelection(bool multipleSelection)
+        {
+            foreach (var filePathSelect in PathsAnalyzed)
+                filePathSelect.Selected = multipleSelection;
+        }
+
+        private void SetEmptyPlatforms()
         {
             PlatformsSource = new ObservableCollection<SelectableOption>();
             PlatformsDestination = new ObservableCollection<SelectableOption>();
-            PathsAnalyzed = new ObservableCollection<SelectableOption<GameLink>>(); 
+        }
+
+        private void SetEmptyPaths()
+        {
+            PathsAnalyzed = new ObservableCollection<SelectableOption<GameLink>>();
         }
 
     }

--- a/Chustasoft.GamersPlatformUtils.Infrastructure/Chustasoft.GamersPlatformUtils.Infrastructure.csproj
+++ b/Chustasoft.GamersPlatformUtils.Infrastructure/Chustasoft.GamersPlatformUtils.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bugs solved:

- #70: Steam secondary path isn't loaded
	

New Implementations

- #69 : Cleaner and Linker tab alignment
  - Loading on both tabs
  - SelectListView actions for controlling multiple selection and cleaning results in both tabs
  - Improved loading style
  - References updated